### PR TITLE
Add Jest test framework to API

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -5,7 +5,8 @@
   "main": "index.js",
   "scripts": {
     "start": "node index.js",
-    "dev": "nodemon index.js"
+    "dev": "nodemon index.js",
+    "test": "jest"
   },
   "keywords": [],
   "author": "",
@@ -15,6 +16,7 @@
     "express": "^5.1.0"
   },
   "devDependencies": {
+    "jest": "^30.0.4",
     "nodemon": "^3.1.10"
   }
 }

--- a/api/test/basic.test.js
+++ b/api/test/basic.test.js
@@ -1,0 +1,5 @@
+const sum = (a, b) => a + b;
+
+test('adds numbers', () => {
+  expect(sum(1, 2)).toBe(3);
+});


### PR DESCRIPTION
## Summary
- add Jest as dev dependency for API
- define `test` npm script
- provide a simple example test

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68759b7fdac88320b7bdc98665248810